### PR TITLE
update to v2.3 basis templates -- for real this time

### DIFF
--- a/bin/trim_basis_templates
+++ b/bin/trim_basis_templates
@@ -20,7 +20,7 @@ def trim_template(infile, outfile):
     hdus.append(fits.PrimaryHDU(fx[0].data[0::n, 0::n], header=fx[0].header))
     hdus.append(fits.BinTableHDU(fx[1].data[0::n], header=fx[1].header))
     hdus.append(fits.ImageHDU(fx[2].data[0::n], header=fx[2].header))    
-    hdus.writeto(outfile, clobber=True)
+    hdus.writeto(outfile, overwrite=True)
         
 def trim_qso(infile, outfile):
     print(infile, '->', outfile)
@@ -35,7 +35,7 @@ def trim_qso(infile, outfile):
 
     hdus.append(fits.ImageHDU(fx[5].data[:, 0::n], header=fx[5].header))
     hdus.append(fits.ImageHDU(fx[6].data[0::n], header=fx[6].header))
-    hdus.writeto(outfile, clobber=True)    
+    hdus.writeto(outfile, overwrite=True)    
     
 def main():
     parser = optparse.OptionParser(usage = "%prog [options]")


### PR DESCRIPTION
The v2.3 testdata were ostensibly updated in #6 but that was premature because we were in the middle of migrating to the svn repository of the basis templates and I was still working on various updates (specifically just on the BGS templates).  This only affected the `desisim-testdata` repository and nothing else so I don't feel too bad.

After merging this I'm going to tag 0.3.3 so that the `desisim` and `desitarget` Travis tests can pass.