### PR TITLE
Custom module file

### DIFF
--- a/etc/desisim-testdata.module
+++ b/etc/desisim-testdata.module
@@ -1,0 +1,78 @@
+#%Module1.0
+# The first line of this file tells Modules that this is a module file.
+# DO NOT ALTER IT!
+#
+# ABOUT THIS FILE
+#
+# This file is designed to be processed by Python.  Specifically, this file
+# will be read into a string, and the .format() method will be applied to it.
+# This file is not a valid module file on its own.
+#
+# METADATA AND DOCUMENTATION SECTION
+#
+# This function is part of the Modules help system.  You can modify
+# the second line if needed, but most products should
+# leave this alone.
+#
+proc ModulesHelp {{ }} {{
+    global product version
+    puts stderr "This module adds $product/$version to your environment."
+}}
+#
+# These variables are used below.  The product variable should be set to
+# the name of the product and never changed.  The version variable will
+# be set at install time, so it should be left alone.  The conflict line
+# prevents multiple versions from being loaded simultaneously.  Do not
+# change it.
+#
+set product {name}
+set version {version}
+conflict $product
+#
+# The line below is another part of the Modules help system.  You can
+# modify the part in quotes if you really need to, but most products should
+# leave this alone.
+#
+module-whatis "Sets up $product/$version in your environment."
+#
+# DEPENDENCIES SECTION
+#
+# If your product requires other software to function, that should be declared
+# here.  There are two types of dependencies: mandatory and optional.
+# A mandatory dependency is a module load command followed by a prereq
+# command.  An optional dependency is not followed by a prereq statement.
+#
+# NO DEPENDENCIES
+#
+# ENVIRONMENT SECTION
+#
+# The PRODUCT_ROOT and PRODUCT_DIR variables are used to set other
+# environment variables but are not exported to the actual environment.
+# If you are not working at NERSC, but still want to use Modules, you
+# will need to set the DESI_PRODUCT_ROOT environment variable
+#
+if {{[info exists env(DESI_PRODUCT_ROOT)]}} {{
+    set code_root $env(DESI_PRODUCT_ROOT)/code
+}} else {{
+    set code_root {product_root}
+}}
+set PRODUCT_DIR $code_root/$product/$version
+#
+# This line creates an environment variable pointing to the install
+# directory of your product.
+#
+setenv DESISIM_TESTDATA $PRODUCT_DIR
+#
+# The lines below set various other environment variables.  They assume the
+# template product layout.  These will be set or commented as needed by the
+# desiInstall script.
+#
+{needs_bin}prepend-path PATH $PRODUCT_DIR/bin
+{needs_python}prepend-path PYTHONPATH $PRODUCT_DIR/lib/{pyversion}/site-packages
+{needs_trunk_py}prepend-path PYTHONPATH $PRODUCT_DIR{trunk_py_dir}
+{needs_ld_lib}prepend-path LD_LIBRARY_PATH $PRODUCT_DIR/lib
+{needs_idl}prepend-path IDL_PATH +$PRODUCT_DIR/pro
+#
+# Add any non-standard Module code below this point.
+#
+setenv DESI_BASIS_TEMPLATES $PRODUCT_DIR/desi/spectro/templates/basis_templates/v3.2

--- a/etc/desisim-testdata.module
+++ b/etc/desisim-testdata.module
@@ -75,4 +75,5 @@ setenv DESISIM_TESTDATA $PRODUCT_DIR
 #
 # Add any non-standard Module code below this point.
 #
-setenv DESI_BASIS_TEMPLATES $PRODUCT_DIR/desi/spectro/templates/basis_templates/v3.2
+pushenv DESI_ROOT $PRODUCT_DIR/desi
+pushenv DESI_BASIS_TEMPLATES $PRODUCT_DIR/desi/spectro/templates/basis_templates/v3.2


### PR DESCRIPTION
Adds a custom module file that solves two issues:

1. Loading the desisim-testdata module at NERSC attempts to define the environment variable `DESISIM-TESTDATA`, which is not a valid variable name (contains a hyphen), since desisim-testdata doesn't have a module file and using the default one from desiutil sets the variable name containing the location of the package to the name of the package. The custom module file added in this branch defines `DESISIM_TESTDATA` (underscore instead of hyphen) instead.
2. Loading the desisim-testdata module at NERSC does not set `DESI_BASIS_TEMPLATES`, which defines where desisim looks for templates, to point to the test data contained in the package. The custom module file added in this branch sets `DESI_BASIS_TEMPLATES` directly when loading the module.

I tested these changes on Cori as the desi user with:
```
% source /global/common/software/desi/desi_environment.sh main
% desiInstall -v -r /global/common/software/desi/cori/desiconda/20211217-2.0.0 desisim-testdata branches/modulefile
% module load desisim-testdata/modulefile
% printf "$DESISIM_TESTDATA \n$DESI_BASIS_TEMPLATES\n"
/global/common/software/desi/cori/desiconda/20211217-2.0.0/code/desisim-testdata/modulefile
/global/common/software/desi/cori/desiconda/20211217-2.0.0/code/desisim-testdata/modulefile/desi/spectro/templates/basis_templates/v3.2
% module unload desisim-testdata
% printf "$DESISIM_TESTDATA \n$DESI_BASIS_TEMPLATES\n"


% rm -r /global/common/software/desi/cori/desiconda/20211217-2.0.0/code/desisim-testdata/modulefile
```

@sbailey please have a look and merge when ready.